### PR TITLE
Add A+PTR support

### DIFF
--- a/src/add_record_form.php
+++ b/src/add_record_form.php
@@ -32,9 +32,9 @@ if(isset($_REQUEST['name'])) {
 
 if($_REQUEST['mode'] == 'records') {
     if ($use_ipv6) {
-        $smarty->assign('typearray', array('A','AAAA','AAAA+PTR','NS','MX','PTR','TXT','CNAME','SRV','SPF'));
+        $smarty->assign('typearray', array('A','A+PTR','AAAA','AAAA+PTR','NS','MX','PTR','TXT','CNAME','SRV','SPF'));
     } else {
-        $smarty->assign('typearray', array('A','NS','MX','PTR','TXT','CNAME','SRV','SPF'));
+        $smarty->assign('typearray', array('A','A+PTR','NS','MX','PTR','TXT','CNAME','SRV','SPF'));
     }
 } else if ($_REQUEST['mode'] == 'default_records') {
     if ($use_ipv6) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -223,6 +223,7 @@ function get_type($type) {
     if($type == 'S') return 'SOA';
     if($type == 'N') return 'NS';
     if($type == 'A') return 'A';
+    if($type == '=') return 'A+PTR';
     if($type == '3') return 'AAAA';
     if($type == '6') return 'AAAA+PTR';
     if($type == 'M') return 'MX';
@@ -239,6 +240,7 @@ function set_type($type) {
     if($type == 'SOA') return 'S';
     if($type == 'NS') return 'N';
     if($type == 'A') return 'A';
+    if($type == 'A+PTR') return '=';
     if($type == 'AAAA') return '3';
     if($type == 'AAAA+PTR') return '6';
     if($type == 'MX') return 'M';
@@ -341,6 +343,15 @@ function verify_record($name,$type,$address,$distance,$weight,$port,$ttl) {
         if(check_domain_name_format($name) == FALSE) {
             return "\"$name\" is not a valid A record name";
         }
+    }
+
+    if ($type == '=') {
+      if(validate_ip($address) == FALSE) {
+          return "\"$address\" is not a valid A+PTR record address";
+      }
+      if(check_domain_name_format($name) == FALSE) {
+          return "\"$name\" is not a valid A+PTR record name";
+      }
     }
 
     // verify AAAA record
@@ -618,6 +629,8 @@ function build_data_line($row,$domain) {
 
     if($row['type'] == 'A') {
         $s = "+".$row['host'].":".$row['val'].":".$row['ttl']."\n";
+    } else if($row['type'] == '=') {
+        $s = "=".$row['host'].":".$row['val'].":".$row['ttl']."\n";
     } else if($row['type'] == 'M') {
         $s = "@".$row['host']."::".$row['val'].":".$row['distance'].":".$row['ttl']."\n";
     } else if($row['type'] == 'N') {
@@ -664,7 +677,13 @@ function parse_dataline($line) {
         $out_array['val'] = $array[1];
         $out_array['distance'] = '';
         $out_array['ttl'] = $array[2];
-    } else if(strncmp('C', $line, 1) == 0) {
+    } else if(strncmp('=', $line, 1) == 0) {
+        $out_array['host'] = $array[0];
+        $out_array['type'] = '=';
+        $out_array['val'] = $array[1];
+        $out_array['distance'] = '';
+        $out_array['ttl'] = $array[2];
+    }else if(strncmp('C', $line, 1) == 0) {
         $out_array['host'] = $array[0];
         $out_array['type'] = 'C';
         $out_array['val'] = $array[1];

--- a/src/records.php
+++ b/src/records.php
@@ -331,6 +331,16 @@ if(!isset($_REQUEST['record_mode']) || $_REQUEST['record_mode'] == 'delete_cance
             '".set_type($_REQUEST['type'])."',
             :address,
             '".$_REQUEST['ttl']."')";
+
+        } else if($_REQUEST['type'] == 'A+PTR') {
+            $params[':address'] = $_REQUEST['address'];
+            $q = "insert into records
+            (domain_id,host,type,val,ttl) values(
+            '".get_dom_id($domain)."',
+            '$name',
+            '".set_type($_REQUEST['type'])."',
+            :address,
+            '".$_REQUEST['ttl']."')";
         } else if($_REQUEST['type'] == 'AAAA') {
             $address = uncompress_ipv6($_REQUEST['address']);
             $params[':address'] = $address;


### PR DESCRIPTION
Support for `A+PTR` in the same manner as `AAAA+PTR`.  As per tinydns norm, you still have to create the appropriate in-addr.arpa zone for the PTR record to be served.